### PR TITLE
fix: Update average grade access to use dictionary syntax

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -320,7 +320,7 @@
                                                 {{ subject }}
                                             </span>
                                         </span>
-                                        <strong class="text-{{ 'success' if avg_data.average <= 2 else 'warning' if avg_data.average <= 4 else 'danger' }}">{{ avg_data.average }}</strong>
+                                        <strong class="text-{{ 'success' if avg_data['average'] <= 2 else 'warning' if avg_data['average'] <= 4 else 'danger' }}">{{ avg_data['average'] }}</strong>
                                     </div>
                                 {% endfor %}
                                 <div class="mt-3">

--- a/templates/semester_grades.html
+++ b/templates/semester_grades.html
@@ -71,7 +71,7 @@
                                             {{ subject }}
                                         </span>
                                         <div class="grade-average-info">
-                                            <span class="grade-average-value">{{ "%.2f"|format(avg.average or 0) }}</span>
+                                            <span class="grade-average-value">{{ "%.2f"|format(avg['average'] or 0) }}</span>
                                             <small class="text-muted">({{ avg.count }} {% if avg.count == 1 %}Note{% else %}Noten{% endif %})</small>
                                         </div>
                                     </div>

--- a/templates/statistics.html
+++ b/templates/statistics.html
@@ -183,7 +183,7 @@
                                         </small>
                                     </div>
                                     <div class="d-flex align-items-center">
-                                        <span class="badge bg-{{ 'success' if data.average <= 2 else 'warning' if data.average <= 4 else 'danger' }} me-2">⌀ {{ data.average }}</span>
+                                        <span class="badge bg-{{ 'success' if data['average'] <= 2 else 'warning' if data['average'] <= 4 else 'danger' }} me-2">⌀ {{ data['average'] }}</span>
                                         {% if data.trend == 'improving' %}
                                             <i class="fas fa-arrow-up text-success" title="Verbesserung"></i>
                                         {% elif data.trend == 'declining' %}
@@ -212,7 +212,7 @@
                             <div class="d-flex justify-content-between align-items-center mb-2">
                                 <span>{{ year }}</span>
                                 <div>
-                                    <span class="badge bg-{{ 'success' if data.average <= 2 else 'warning' if data.average <= 4 else 'danger' }}">{{ data.average }}</span>
+                                    <span class="badge bg-{{ 'success' if data['average'] <= 2 else 'warning' if data['average'] <= 4 else 'danger' }}">{{ data['average'] }}</span>
                                     <small class="text-muted ms-1">({{ data.count }} Noten)</small>
                                 </div>
                             </div>


### PR DESCRIPTION
This pull request updates how average grade data is accessed in several templates by switching from attribute-style access (e.g., `data.average`) to dictionary-style access (e.g., `data['average']`). This change ensures consistency and likely improves compatibility with the data structures being used.

**Template variable access updates:**

* In `templates/index.html`, average values for subjects are now accessed using dictionary keys (`avg_data['average']`) instead of attributes (`avg_data.average`).
* In `templates/semester_grades.html`, subject average values are accessed as `avg['average']` instead of `avg.average`.
* In `templates/statistics.html`, both the "Fach-Performance" and "Jahres-Durchschnitte" sections now use dictionary-style access (`data['average']`) for average values. [[1]](diffhunk://#diff-9e97513f957f41afbfb73b6fd33bab3de8b9fdcfb3e1891ce91d81191d61a6cfL186-R186) [[2]](diffhunk://#diff-9e97513f957f41afbfb73b6fd33bab3de8b9fdcfb3e1891ce91d81191d61a6cfL215-R215)