### PR TITLE
feat: Ensure all subjects have 'average' and 'avg_grade' keys

### DIFF
--- a/routes/main.py
+++ b/routes/main.py
@@ -172,6 +172,12 @@ def index():
                     # Template erwartet 'average' statt 'avg_grade'
                     subject_summary[subject]['average'] = subject_summary[subject]['avg_grade']
             
+            # Stelle sicher, dass ALLE Fächer den 'average' Schlüssel haben
+            for subject in subject_summary.keys():
+                if 'average' not in subject_summary[subject]:
+                    subject_summary[subject]['average'] = 0
+                    subject_summary[subject]['avg_grade'] = 0
+            
             print(f"DEBUG: Processed {len(all_grades)} total grades for subject summary")
         except Exception as e:
             print(f"ERROR building subject summary from grades: {e}")


### PR DESCRIPTION
This pull request adds a safeguard to ensure that all subjects in the `subject_summary` dictionary have both the `average` and `avg_grade` keys set, preventing potential errors when these keys are missing.

Data consistency improvement:

* Ensures every subject in `subject_summary` has the `average` and `avg_grade` keys, defaulting them to `0` if they are missing.